### PR TITLE
Add config file validation to upload method

### DIFF
--- a/html/components/configuration-form.js
+++ b/html/components/configuration-form.js
@@ -186,15 +186,19 @@ class ConfigurationForm extends React.Component {
               id: `${key}-${keyLocation}-file-upload`,
               key: `${key}-${keyLocation}-file-upload`,
               type: 'file',
+              accept: '.xml',
               onChange: (e) => {
                 const file = e?.target?.files[0]
-                if (file) {
+                if (file && file?.type === 'text/xml' && !/\s/g.test(file?.name)) {
                   uploadFile(file, UPLOAD_LOCATION_CONFIGURATION_ENDPOINT, true)
                   this.setState(prevState => {
                     let newConfigFile = Object.assign({}, prevState.configFile);
                     newConfigFile.locations[key][keyLocation] = file?.name
                     return { config: newConfigFile, configurationsToSave: [...prevState?.configurationsToSave, file?.name] };
                   })
+                } else {
+                  alert('Incorrect file, config file must be an xml file and have no spaces in filename')
+                  e.target.value = null
                 }
               }
             }),


### PR DESCRIPTION
File name with spaces:
https://gyazo.com/7b2c7277ceb5521e67e5d21a22fa5c13
Trying to upload .js file:
https://gyazo.com/eecd49c5d0cc7758da3e192dbafba8ca
Prof that normal xml file upload still works:
https://gyazo.com/547692f9bb0a6ac9b3692ea58ddbc5ad
